### PR TITLE
Added install_options param + hack for removing package on windows hosts

### DIFF
--- a/examples/windows.pp
+++ b/examples/windows.pp
@@ -1,0 +1,7 @@
+class { 'sunjdk':
+  ensure          => 'present',
+  jdk_version     => '6u32_64b',
+  install_options => {
+    'INSTALLDIR'  => 'C:\Program Files (x86)\Java\JDK 1.6'
+  },
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 #   ensure      => 'present',
 # }
 #
-class sunjdk($jdk_version,$ensure) {
+class sunjdk($jdk_version, $ensure='present', $install_options=undef) {
   if ! $jdk_version {
     $jdk_version = 'latest'
   } else {

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -1,13 +1,26 @@
 class sunjdk::windows {
+
   include "sunjdk::jdk_releases::jdk_${sunjdk::real_jdk_version}"
 
-  package { 'jdk':
-    ensure          => $sunjdk::ensure,
-    provider        => 'msi',
-    source          => "C:\\temp\\jdk_${sunjdk::real_jdk_version}\\jdk_${sunjdk::real_jdk_version}.msi",
-    install_options => {
-      'INSTALLDIR'  => 'C:\Program Files\Java\JDK 1.6'
-    },
-    require         => File["jdk_${sunjdk::real_jdk_version}.msi"],
+  case $sunjdk::ensure {
+
+    'present': {
+      package { 'jdk':
+        ensure          => $sunjdk::ensure,
+        provider        => 'msi',
+        source          => "C:\\temp\\jdk_${sunjdk::real_jdk_version}\\jdk_${sunjdk::real_jdk_version}.msi",
+        install_options => $sunjdk::install_options,
+        require         => File["jdk_${sunjdk::real_jdk_version}.msi"],
+      }
+    }
+
+    'absent': {
+      exec { "remove jdk_${sunjdk::real_jdk_version}.msi":
+        command => "C:\\Windows\\system32\\msiexec.exe /qn /norestart /x C:\\temp\\jdk_${sunjdk::real_jdk_version}\\jdk_${sunjdk::real_jdk_version}.msi",
+      }
+    }
+
+    default: { notice("ensure parameter ${sunjdk::ensure} is not supported") }
   }
+
 }


### PR DESCRIPTION
This commit adds an option to provide install_options to the package resource for windows provisioning.
Because windows support is still not optimal, the 'absent' part of the windows package resource doesnt' work and I have lost the urge to boldly go where no man has gone before, I introduced a hack to remove the jdk package from windows hosts..
I know this is not the best thing, but it beats having to manually remove the old version from the host before installing the new one...
