### PR TITLE
Make jdk package name configurable

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,5 +1,6 @@
 define sunjdk::instance(
   $jdk_version=undef,
+  $pkg_name=undef,
   $versionlock=false,
   $package_code='',
   $ensure='present',
@@ -12,22 +13,31 @@ define sunjdk::instance(
     $real_jdk_version = $jdk_version
   }
 
+  if ! $pkg_name {
+    $real_pkg_name = 'jdk'
+  } else {
+    $real_pkg_name = $pkg_name
+  }
+
   case $::operatingsystem {
     redhat, centos: {
       sunjdk::redhat { $name:
         ensure      => $ensure,
         jdk_version => $real_jdk_version,
+        pkg_name    => $real_pkg_name,
         versionlock => $versionlock
       }
     }
     ubuntu: {
       sunjdk::ubuntu { $name:
+        pkg_name    => $real_pkg_name,
         jdk_version => $real_jdk_version
       }
     }
     windows: {
       sunjdk::windows { $name:
         ensure          => $ensure,
+        pkg_name        => $real_pkg_name,
         jdk_version     => $real_jdk_version,
         package_code    => $package_code,
         install_options => $install_options

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -1,5 +1,6 @@
 define sunjdk::redhat(
   $jdk_version=undef,
+  $pkg_name=undef,
   $versionlock=false,
   $ensure='present',
 ) {
@@ -12,7 +13,7 @@ define sunjdk::redhat(
         }
       }
 
-      package { "jdk":
+      package { $pkg_name :
         ensure   => $jdk_version,
         require  => Package['glibc.i686']
       }
@@ -51,18 +52,18 @@ define sunjdk::redhat(
 
       case $versionlock {
         true: {
-          packagelock { "jdk": }
+          packagelock { $pkg_name : }
         }
         false: {
-          packagelock { "jdk": ensure => absent }
+          packagelock { $pkg_name : ensure => absent }
         }
         default: { fail('Class[Sunjdk::Redhat]: parameter versionlock must be true or false')}
       }
     }
     'absent': {
-      packagelock { "jdk": ensure => absent }
+      packagelock { $pkg_name : ensure => absent }
       ->
-      package { "jdk":
+      package { $pkg_name :
         ensure => absent
       }
 

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -1,4 +1,4 @@
-define sunjdk::ubuntu($jdk_version) {
+define sunjdk::ubuntu($jdk_version, $pkg_name) {
     file { '/var/cache/debconf/java6.seeds' :
         ensure  => present,
         source  => 'puppet:///modules/sunjdk/java6.seeds',

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -1,4 +1,4 @@
-define sunjdk::windows($jdk_version, $package_code='', $ensure='present', $install_options=undef) {
+define sunjdk::windows($jdk_version, $pkg_name, $package_code='', $ensure='present', $install_options=undef) {
 
   include "sunjdk::jdk_releases::jdk_${jdk_version}"
 

--- a/spec/defines/sunjdk_instance_spec.rb
+++ b/spec/defines/sunjdk_instance_spec.rb
@@ -4,47 +4,68 @@ describe 'sunjdk::instance' do
 
   context 'installing sunjdk instance' do
     let (:title) { 'installing sunjdk' }
-    let (:facts) { { :operatingsystem => 'redhat' } }
-    let(:params) { { :ensure => 'present', :jdk_version => '1.6.0_32-fcs.i586' } }
 
-    it { should contain_package("glibc.i686").with(
+    context 'on RedHat' do
+      let (:facts) { { :operatingsystem => 'redhat' } }
+      let(:params) { { :ensure => 'present', :jdk_version => '1.6.0_32-fcs.i586' } }
+
+      it { should contain_package("glibc.i686").with(
         :ensure => 'present'
-      )
-    }
+        )
+      }
 
-    it { should contain_package("jdk").with(
-        :ensure => '1.6.0_32-fcs.i586',
-        :require => 'Package[glibc.i686]'
-      )
-    }
+      it { should contain_package("jdk").with(
+          :ensure => '1.6.0_32-fcs.i586',
+          :require => 'Package[glibc.i686]'
+        )
+      }
 
-    it { should contain_file('keytool').with(
-        :ensure => 'link',
-        :target => '/usr/java/default/bin/keytool',
-        :path => '/usr/bin/keytool',
-        :require => 'Package[jdk]'
-      )
-    }
+      it { should contain_file('keytool').with(
+          :ensure => 'link',
+          :target => '/usr/java/default/bin/keytool',
+          :path => '/usr/bin/keytool',
+          :require => 'Package[jdk]'
+        )
+      }
 
-    it { should contain_file('jps').with(
-        :ensure => 'link',
-        :target => '/usr/java/default/bin/jps',
-        :path => '/usr/bin/jps',
-        :require => 'Package[jdk]'
-      )
-    }
+      it { should contain_file('jps').with(
+          :ensure => 'link',
+          :target => '/usr/java/default/bin/jps',
+          :path => '/usr/bin/jps',
+          :require => 'Package[jdk]'
+        )
+      }
 
-    it { should contain_file('/etc/ld.so.conf.d/jdk.conf').with(
-        :ensure => 'file',
-        :content => '/usr/java/default/jre/lib/amd64/server'
-      )
-    }
+      it { should contain_file('/etc/ld.so.conf.d/jdk.conf').with(
+          :ensure => 'file',
+          :content => '/usr/java/default/jre/lib/amd64/server'
+        )
+      }
 
-    it { should contain_exec('ldconfig -f /etc/ld.so.conf').with(
-        :refreshonly => true,
-        :subscribe => 'File[/etc/ld.so.conf.d/jdk.conf]'
-      )
-    }
+      it { should contain_exec('ldconfig -f /etc/ld.so.conf').with(
+          :refreshonly => true,
+          :subscribe => 'File[/etc/ld.so.conf.d/jdk.conf]'
+        )
+      }
+
+      context 'with pkg_name => jdk1.8.0_31' do
+        let(:params) { { :ensure => 'present', :pkg_name => 'jdk1.8.0_31', :jdk_version => '1.8.0_31-fcs' } }
+
+        it { should contain_package("jdk1.8.0_31").with(
+            :ensure => '1.8.0_31-fcs'
+          )
+        }
+
+        context 'with versionlock => true' do
+          let(:params) { { :ensure => 'present', :pkg_name => 'jdk1.8.0_31', :jdk_version => '1.8.0_31-fcs', :versionlock => true } }
+          it { should contain_package("jdk1.8.0_31").with(
+              :ensure => '1.8.0_31-fcs'
+            )
+          }
+
+          it { should contain_packagelock("jdk1.8.0_31") }
+        end
+      end
+    end
   end
-
 end


### PR DESCRIPTION
As Oracle changed the name of the JDK package from "jdk" to "jdk<version>",
we need to make the package name configurable.

Possibilities:
* Derive the package name from the version
* Provide the package name explicitly

As deriving the name from the version seems rather fragile, I opted to provide
the package name explicitly. An example:

    sunjdk:: instance { 'installing jdk1.8.0_31':
      ensure      => 'present',
      pkg_name    => 'jdk1.8.0_31',
      jdk_version => 1.8.0_31-fcs',
      versionlock => true
    }

As the name and the version are now rather redundant, we can optionally leave out the version.